### PR TITLE
[not for merge] Exclude from init option

### DIFF
--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -37,7 +37,7 @@ int main(int argc, const char* argv[]) {
     }
 
     // This Sold class instrance is used only to get filename_to_soname map.
-    Sold sold(argv[1], {}, {}, {}, {}, {}, false, false);
+    Sold sold(argv[1], {}, {}, {}, {}, {}, {}, false, false);
 
     auto b = ReadELF(argv[1]);
     b->ReadDynSymtab(sold.filename_to_soname());

--- a/sold.h
+++ b/sold.h
@@ -36,8 +36,9 @@
 class Sold {
 public:
     Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, const std::vector<std::string>& exclude_dirs,
-         const std::vector<std::string>& exclude_finis, const std::vector<std::string> custome_library_path,
-         const std::vector<std::string>& exclude_runpath_pattern, bool emit_section_header, bool delete_unused_DT_STRTAB);
+         const std::vector<std::string>& exclude_inits, const std::vector<std::string>& exclude_finis,
+         const std::vector<std::string> custome_library_path, const std::vector<std::string>& exclude_runpath_pattern,
+         bool emit_section_header, bool delete_unused_DT_STRTAB);
 
     void Link(const std::string& out_filename);
 
@@ -457,6 +458,7 @@ private:
     std::vector<std::string> ld_library_paths_;
     const std::vector<std::string> exclude_sos_;
     const std::vector<std::string> exclude_dirs_;
+    const std::vector<std::string> exclude_inits_;
     const std::vector<std::string> exclude_finis_;
     const std::vector<std::string> custome_library_path_;
     const std::vector<std::string> exclude_runpath_pattern_;


### PR DESCRIPTION
# Abstract
When we debug `sold`, we want to skip the initialization step of some linked shared object. This PR enables it by `--exclude-from-init hoge.so`.

# Details
`init_array` in ELF format is an array of function pointers. `ld-linux.so` calls all functions in `init_array` in the startup. It includes function pointers to functions with `__attribute__((constructor))`, constructors of global scoped objects.

When `sold` links multiple shared objects, it generates a new `init_array` by combining all `init_arrray`s in linked shared objects.

When you specify `--exclude-from-init hoge.so`, `sold` skips to combine `init_arrray` of `hoge.so`. This skips the initialization step of `hoge.so`. Skipping it is useful when you want to isolate the problem.